### PR TITLE
extend metrics with pathwithnamespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 			Name: "gitlab_ci_pipeline_time_since_last_run_seconds",
 			Help: "Elapsed time since most recent GitLab CI pipeline run.",
 		},
-		[]string{"project", "pathwithnamespace", "ref", "id"},
+		[]string{"projectWithNamespace", "ref", "id"},
 	)
 
 	lastRunDuration = prometheus.NewGaugeVec(
@@ -36,7 +36,7 @@ var (
 			Name: "gitlab_ci_pipeline_last_run_duration_seconds",
 			Help: "Duration of last pipeline run",
 		},
-		[]string{"project", "pathwithnamespace", "ref", "id"},
+		[]string{"projectWithNamespace", "ref", "id"},
 	)
 
 	status = prometheus.NewGaugeVec(
@@ -44,7 +44,7 @@ var (
 			Name: "gitlab_ci_pipeline_status",
 			Help: "GitLab CI pipeline current status",
 		},
-		[]string{"project", "pathwithnamespace", "ref", "status", "id"},
+		[]string{"projectWithNamespace", "ref", "status", "id"},
 	)
 )
 
@@ -84,37 +84,58 @@ func getGitlabInfo() {
 	client := gitlab.NewClient(nil, settings.Gitlab.Token)
 	client.SetBaseURL(settings.Gitlab.Url)
 
-	for {
-		// get all projects
-		opt := &gitlab.ListProjectsOptions{Owned: &settings.Gitlab.Owned}
-		projects, _, err := client.Projects.ListProjects(opt)
+	// get all projects
+	opt := &gitlab.ListProjectsOptions{
+		ListOptions: gitlab.ListOptions{
+			PerPage: 50,
+			Page:    1,
+		},
+		Owned: &settings.Gitlab.Owned,
+	}
+
+	for{
+		projects, resp, err := client.Projects.ListProjects(opt)
 		if err != nil {
 			log.Fatalln(err)
 		}
 
-		// for each project, get pipelines and status
+		// List all the projects we've found so far.
 		for _, project := range projects {
-			pipelines, _, _ := client.Pipelines.ListProjectPipelines(project.ID, &gitlab.ListProjectPipelinesOptions{})
-			var lastPipeline *gitlab.Pipeline
-			if len(pipelines) != 0 {
-				lastPipeline, _, _ = client.Pipelines.GetPipeline(project.ID, pipelines[0].ID)
-				lastRunDuration.WithLabelValues(project.Name, project.PathWithNamespace, pipelines[0].Ref, strconv.Itoa(pipelines[0].ID)).Set(float64(lastPipeline.Duration))
-				for _, s := range []string{"success", "failed", "running"} {
-					if s == lastPipeline.Status {
-						status.WithLabelValues(project.Name, project.PathWithNamespace, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(1)
-					} else {
-						status.WithLabelValues(project.Name, project.PathWithNamespace, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(0)
-					}
+
+		pipelines, _, _ := client.Pipelines.ListProjectPipelines(project.ID, &gitlab.ListProjectPipelinesOptions{})
+		var lastPipeline *gitlab.Pipeline
+
+		if len(pipelines) != 0 {
+
+			lastPipeline, _, _ = client.Pipelines.GetPipeline(project.ID, pipelines[0].ID)
+			lastRunDuration.WithLabelValues(project.NameWithNamespace, pipelines[0].Ref, strconv.Itoa(pipelines[0].ID)).Set(float64(lastPipeline.Duration))
+
+			for _, s := range []string{"success", "failed", "running"} {
+				if s == lastPipeline.Status {
+					status.WithLabelValues(project.NameWithNamespace, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(1)
+				} else {
+					status.WithLabelValues(project.NameWithNamespace, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(0)
 				}
-				timeSinceLastRun.WithLabelValues(
-					project.Name,
-					project.PathWithNamespace,
-					pipelines[0].Ref,
-					strconv.Itoa(pipelines[0].ID)).Set(
-					float64(time.Since(*lastPipeline.CreatedAt).Round(time.Second).Seconds()))
 			}
+
+			timeSinceLastRun.WithLabelValues(
+				project.NameWithNamespace,
+				pipelines[0].Ref,
+				strconv.Itoa(pipelines[0].ID)).Set(
+				float64(time.Since(*lastPipeline.CreatedAt).Round(time.Second).Seconds()))
+			}
+
 		}
 
-		time.Sleep(time.Duration(settings.Gitlab.Refresh) * time.Second)
+		// Exit the loop when we've seen all pages.
+		if opt.Page >= resp.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		opt.Page = resp.NextPage
+
 	}
+
+	time.Sleep(time.Duration(settings.Gitlab.Refresh) * time.Second)
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 			Name: "gitlab_ci_pipeline_time_since_last_run_seconds",
 			Help: "Elapsed time since most recent GitLab CI pipeline run.",
 		},
-		[]string{"project", "ref", "id"},
+		[]string{"project", "pathwithnamespace", "ref", "id"},
 	)
 
 	lastRunDuration = prometheus.NewGaugeVec(
@@ -36,7 +36,7 @@ var (
 			Name: "gitlab_ci_pipeline_last_run_duration_seconds",
 			Help: "Duration of last pipeline run",
 		},
-		[]string{"project", "ref", "id"},
+		[]string{"project", "pathwithnamespace", "ref", "id"},
 	)
 
 	status = prometheus.NewGaugeVec(
@@ -44,7 +44,7 @@ var (
 			Name: "gitlab_ci_pipeline_status",
 			Help: "GitLab CI pipeline current status",
 		},
-		[]string{"project", "ref", "status", "id"},
+		[]string{"project", "pathwithnamespace", "ref", "status", "id"},
 	)
 )
 
@@ -98,16 +98,17 @@ func getGitlabInfo() {
 			var lastPipeline *gitlab.Pipeline
 			if len(pipelines) != 0 {
 				lastPipeline, _, _ = client.Pipelines.GetPipeline(project.ID, pipelines[0].ID)
-				lastRunDuration.WithLabelValues(project.Name, pipelines[0].Ref, strconv.Itoa(pipelines[0].ID)).Set(float64(lastPipeline.Duration))
+				lastRunDuration.WithLabelValues(project.Name, project.PathWithNamespace, pipelines[0].Ref, strconv.Itoa(pipelines[0].ID)).Set(float64(lastPipeline.Duration))
 				for _, s := range []string{"success", "failed", "running"} {
 					if s == lastPipeline.Status {
-						status.WithLabelValues(project.Name, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(1)
+						status.WithLabelValues(project.Name, project.PathWithNamespace, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(1)
 					} else {
-						status.WithLabelValues(project.Name, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(0)
+						status.WithLabelValues(project.Name, project.PathWithNamespace, pipelines[0].Ref, s, strconv.Itoa(pipelines[0].ID)).Set(0)
 					}
 				}
 				timeSinceLastRun.WithLabelValues(
 					project.Name,
+					project.PathWithNamespace,
 					pipelines[0].Ref,
 					strconv.Itoa(pipelines[0].ID)).Set(
 					float64(time.Since(*lastPipeline.CreatedAt).Round(time.Second).Seconds()))


### PR DESCRIPTION
Extends metrics with the repository-path. This way similar named repositories can be distinguished easily.
solves https://github.com/Labbs/gitlab-ci-pipelines-exporter/issues/3

